### PR TITLE
customized nginx ingress controller manifest for deployment on Amazon…

### DIFF
--- a/aws-eks/nginx-ingress-controller/deploy.yaml
+++ b/aws-eks/nginx-ingress-controller/deploy.yaml
@@ -338,7 +338,8 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -355,12 +356,12 @@ spec:
   ports:
   - appProtocol: http
     name: http
-    port: 80
+    port: 8080
     protocol: TCP
     targetPort: http
   - appProtocol: https
     name: https
-    port: 443
+    port: 8443
     protocol: TCP
     targetPort: https
   selector:
@@ -428,9 +429,11 @@ spec:
         - --controller-class=k8s.io/ingress-nginx
         - --ingress-class=nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
-        - --validating-webhook=:8443
+        - --validating-webhook=:8444
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
+        - --http-port=8080 
+        - --https-port=8443        
         env:
         - name: POD_NAME
           valueFrom:
@@ -461,13 +464,13 @@ spec:
           timeoutSeconds: 1
         name: controller
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: http
           protocol: TCP
-        - containerPort: 443
+        - containerPort: 8443
           name: https
           protocol: TCP
-        - containerPort: 8443
+        - containerPort: 8444
           name: webhook
           protocol: TCP
         readinessProbe:
@@ -485,7 +488,7 @@ spec:
             cpu: 100m
             memory: 90Mi
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE

--- a/aws-eks/nginx-ingress-controller/deploy.yaml
+++ b/aws-eks/nginx-ingress-controller/deploy.yaml
@@ -356,14 +356,14 @@ spec:
   ports:
   - appProtocol: http
     name: http
-    port: 8080
+    port: 80
     protocol: TCP
-    targetPort: http
+    targetPort: 8080
   - appProtocol: https
     name: https
-    port: 8443
+    port: 443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx


### PR DESCRIPTION
…
Amazon EKS with Fargate only

Workaround solution since NGINX Ingress Controller cannot be installed on Fargate worker nodes due to Fargate limiting privileged containers